### PR TITLE
@here and @everyone can now be mentioned

### DIFF
--- a/src/Messages/Mention.php
+++ b/src/Messages/Mention.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace DiscordCommands\Messages;
+
+enum Mention: string
+{
+    case Everyone = '@everyone';
+    case Here = '@here';
+
+    public static function other(int $roleId)
+    {
+        return '<@&'.$roleId.'>';
+    }
+
+    public static function hasMentions(string $content)
+    {
+        return preg_match('#<@&.+?>#', $content) ||
+            str_contains($content, self::Everyone->value) ||
+            str_contains($content, self::Here->value);
+    }
+}

--- a/src/Messages/MentionsRoles.php
+++ b/src/Messages/MentionsRoles.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace DiscordCommands\Messages;
+
+trait MentionsRoles
+{
+    /**
+     * Determine if the given message has mentions
+     */
+    public function hasMentions(): bool
+    {
+        return Mention::hasMentions($this->content());
+    }
+
+    public function mentionedRoleIds(): array
+    {
+        preg_match_all('#<@&(.+?)>#', $this->content(), $matches);
+
+        return $matches[1] ?? [];
+    }
+
+    public function mentionHere()
+    {
+        $this->mention(Mention::Here);
+    }
+
+    public function mentionEveryone()
+    {
+        $this->mention(Mention::Everyone);
+    }
+
+    /**
+     * Mention the given role in the included message
+     */
+    public function mention(int|Mention $role): void
+    {
+        if ($role instanceof Mention) {
+            $this->content .= $role->value;
+        } else {
+            $this->content .= Mention::other($role);
+        }
+    }
+
+    public function isMentioned(int|Mention $role): bool
+    {
+        if ($this->content == null) {
+            return false;
+        }
+
+        if ($role instanceof Mention) {
+            return str_contains($this->content, $role->value);
+        }
+
+        return str_contains($this->content, Mention::other($role));
+    }
+}

--- a/src/Messages/Message.php
+++ b/src/Messages/Message.php
@@ -14,6 +14,7 @@ class Message extends Jsonable implements Hydrateable
 {
     use HasComponents;
     use HasEmbeds;
+    use MentionsRoles;
 
     protected ?string $content;
 
@@ -48,38 +49,6 @@ class Message extends Jsonable implements Hydrateable
     public function hasContent(): bool
     {
         return $this->content != null;
-    }
-
-    /**
-     * Determine if the given message has mentions
-     */
-    public function hasMentions(): bool
-    {
-        return preg_match('#<@&.+?>#', $this->content());
-    }
-
-    public function mentionedRoleIds(): ?array
-    {
-        preg_match_all('#<@&(.+?)>#', $this->content(), $matches);
-
-        return isset($matches[1]) ? $matches[1] : null;
-    }
-
-    /**
-     * Mention the given role in the included message
-     */
-    public function mention(int $roleId): void
-    {
-        $this->content .= '<@&'.$roleId.'>';
-    }
-
-    public function isMentioned(int $roleId): bool
-    {
-        if ($this->content == null) {
-            return false;
-        }
-
-        return str_contains($this->content, '<@&' . $roleId . '>');
     }
 
     public function actionRow(Button ... $buttons)

--- a/src/Messages/WebhookMessage.php
+++ b/src/Messages/WebhookMessage.php
@@ -12,6 +12,7 @@ class WebhookMessage extends Jsonable implements Hydrateable
 {
     use HasComponents;
     use HasEmbeds;
+    use MentionsRoles;
 
     protected ?string $content;
     protected ?string $threadName;
@@ -52,38 +53,6 @@ class WebhookMessage extends Jsonable implements Hydrateable
     public function hasContent(): bool
     {
         return $this->content != null;
-    }
-
-    /**
-     * Determine if the given message has mentions
-     */
-    public function hasMentions(): bool
-    {
-        return preg_match('#<@&.+?>#', $this->content());
-    }
-
-    public function mentionedRoleIds(): array
-    {
-        preg_match_all('#<@&(.+?)>#', $this->content(), $matches);
-
-        return $matches[1] ?? [];
-    }
-
-    /**
-     * Mention the given role in the included message
-     */
-    public function mention(int $roleId): void
-    {
-        $this->content .= '<@&'.$roleId.'> ';
-    }
-
-    public function isMentioned(int $roleId): bool
-    {
-        if ($this->content == null) {
-            return false;
-        }
-
-        return str_contains($this->content, '<@&' . $roleId . '>');
     }
 
     public function createThreadWithName(string $threadName)

--- a/tests/Messages/MessageTest.php
+++ b/tests/Messages/MessageTest.php
@@ -18,6 +18,29 @@ class MessageTest extends TestCase
         $this->message = new Message();
     }
 
+    /**
+     * @test
+     * @dataProvider mentionableSpecialRoles
+     */
+    public function canMentionSpecialRoles(Mention $mention)
+    {
+        $this->assertFalse($this->message->isMentioned($mention));
+        $this->assertFalse($this->message->hasMentions());
+
+        $this->message->mention($mention);
+        $this->assertEquals($mention->value, $this->message->content());
+        $this->assertTrue($this->message->hasMentions());
+        $this->assertTrue($this->message->isMentioned($mention));
+    }
+
+    public static function mentionableSpecialRoles()
+    {
+        return [
+            [Mention::Here],
+            [Mention::Everyone],
+        ];
+    }
+
     /** @test */
     public function canMentionRoles()
     {

--- a/tests/Messages/WebhookMessageTest.php
+++ b/tests/Messages/WebhookMessageTest.php
@@ -17,6 +17,29 @@ class WebhookMessageTest extends TestCase
         $this->message = new WebhookMessage();
     }
 
+    /**
+     * @test
+     * @dataProvider mentionableSpecialRoles
+     */
+    public function canMentionSpecialRoles(Mention $mention)
+    {
+        $this->assertFalse($this->message->isMentioned($mention));
+        $this->assertFalse($this->message->hasMentions());
+
+        $this->message->mention($mention);
+        $this->assertEquals($mention->value, $this->message->content());
+        $this->assertTrue($this->message->hasMentions());
+        $this->assertTrue($this->message->isMentioned($mention));
+    }
+
+    public static function mentionableSpecialRoles()
+    {
+        return [
+            [Mention::Here],
+            [Mention::Everyone],
+        ];
+    }
+
     /** @test */
     public function canMentionRoles()
     {
@@ -25,7 +48,7 @@ class WebhookMessageTest extends TestCase
 
         $roleId = time();
         $this->message->mention($roleId);
-        $this->assertEquals('<@&'.$roleId.'> ', $this->message->content());
+        $this->assertEquals('<@&'.$roleId.'>', $this->message->content());
         $this->assertTrue($this->message->hasMentions());
         $this->assertTrue($this->message->isMentioned($roleId));
     }


### PR DESCRIPTION
Mentioning Discord's special roles the same way as others doesn't quite work correctly.  We actually just need `@here` and `@everyone` in the content to actually trigger notifications.