### PR TITLE
Bugfix: Text fields can now be correctly optional

### DIFF
--- a/src/Messages/Components/Types/TextInput.php
+++ b/src/Messages/Components/Types/TextInput.php
@@ -167,7 +167,10 @@ abstract class TextInput extends Component
             array_merge(
                 parent::jsonSerialize(),
                 $data,
-            )
+            ),
+            function ($value) {
+                return $value !== null;
+            }
         );
     }
 }

--- a/tests/Messages/Components/Types/TextInput/ParagraphInputTest.php
+++ b/tests/Messages/Components/Types/TextInput/ParagraphInputTest.php
@@ -10,16 +10,11 @@ class ParagraphInputTest extends TestCase
     /** @test */
     public function requirementCanBeDisabled()
     {
-        $id = '4';
-        $label = 'my-field';
         $input = new ParagraphInput(
-            $id,
-            $label,
+            '4',
+            'my-field',
             required: false,
         );
-
-        $this->assertEquals(1, $input->style());
-        $this->assertEquals($label, $input->label());
 
         $json = $input->jsonSerialize();
 

--- a/tests/Messages/Components/Types/TextInput/ParagraphInputTest.php
+++ b/tests/Messages/Components/Types/TextInput/ParagraphInputTest.php
@@ -6,6 +6,27 @@ use PHPUnit\Framework\TestCase;
 
 class ParagraphInputTest extends TestCase
 {
+
+    /** @test */
+    public function requirementCanBeDisabled()
+    {
+        $id = '4';
+        $label = 'my-field';
+        $input = new ParagraphInput(
+            $id,
+            $label,
+            required: false,
+        );
+
+        $this->assertEquals(1, $input->style());
+        $this->assertEquals($label, $input->label());
+
+        $json = $input->jsonSerialize();
+
+        $this->assertArrayHasKey('required', $json);
+        $this->assertFalse($json['required']);
+    }
+
     /** @test */
     public function canBeConstructedAndJsonified()
     {
@@ -20,5 +41,8 @@ class ParagraphInputTest extends TestCase
 
         $this->assertArrayHasKey('label', $json);
         $this->assertEquals($input->label(), $json['label']);
+
+        $this->assertArrayHasKey('required', $json);
+        $this->assertEquals($input->isRequired(), $json['required']);
     }
 }

--- a/tests/Messages/Components/Types/TextInput/ShortInputTest.php
+++ b/tests/Messages/Components/Types/TextInput/ShortInputTest.php
@@ -7,6 +7,26 @@ use PHPUnit\Framework\TestCase;
 class ShortInputTest extends TestCase
 {
     /** @test */
+    public function requirementCanBeDisabled()
+    {
+        $id = '4';
+        $label = 'my-field';
+        $input = new ShortInput(
+            $id,
+            $label,
+            required: false,
+        );
+
+        $this->assertEquals(1, $input->style());
+        $this->assertEquals($label, $input->label());
+
+        $json = $input->jsonSerialize();
+
+        $this->assertArrayHasKey('required', $json);
+        $this->assertFalse($json['required']);
+    }
+
+    /** @test */
     public function canBeConstructedAndJsonified()
     {
         $id = '4';
@@ -20,5 +40,8 @@ class ShortInputTest extends TestCase
 
         $this->assertArrayHasKey('label', $json);
         $this->assertEquals($input->label(), $json['label']);
+
+        $this->assertArrayHasKey('required', $json);
+        $this->assertEquals($input->isRequired(), $json['required']);
     }
 }

--- a/tests/Messages/Components/Types/TextInput/ShortInputTest.php
+++ b/tests/Messages/Components/Types/TextInput/ShortInputTest.php
@@ -9,16 +9,11 @@ class ShortInputTest extends TestCase
     /** @test */
     public function requirementCanBeDisabled()
     {
-        $id = '4';
-        $label = 'my-field';
         $input = new ShortInput(
-            $id,
-            $label,
+            '4',
+            'my-field',
             required: false,
         );
-
-        $this->assertEquals(1, $input->style());
-        $this->assertEquals($label, $input->label());
 
         $json = $input->jsonSerialize();
 


### PR DESCRIPTION
In an attempt to filter our nullable values, false values were also incorrectly filtered out.  This is now fixed and `required => false` will no longer be filtered out and will be passed to Discord.