### PR TITLE
Added handling for Discord's formatting options

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Using this library you can build Discord bot commands, process inbound interacti
 - [Installation](#installation)
 - [Creating Messages](#creating-messages)
   - [Mentioning](#mentioning)
+  - [Enriching](#enriching)
   - [Author](#author)
   - [Fields](#fields)
   - [Image](#image)
@@ -72,6 +73,39 @@ $message->mention($roleId);
 
 $message->isMentioned($roleId);
 $message->hasMentions();
+```
+
+### Enriching
+
+Certain information can be enriched on the Discord side, such as linking to channels and timestamps in the user's local time.
+
+**Linking to a Channel**
+
+```php
+use \DiscordCommands\Messages\Message;
+
+$message->setContent('Instead of this channel, go to '.Message::linkChannel(34835835834));
+```
+
+**Linking to a Special Channel**
+
+```php
+use \DiscordCommands\Messages\Message;
+use \DiscordCommands\Messages\GuildNavigation;
+
+$message->setContent('Help find new channels in '.Message::linkInGuild(GuildNavigation::CHANNEL_BROWSER));
+```
+
+**Embedding Timestamps**
+
+```php
+use \DiscordCommands\Messages\Message;
+use \DiscordCommands\Messages\TimestampFormat;
+
+$message->setContent('The contest runs until '.Message::timestamp(time()+6000));
+
+// You can also customize formatting
+$message->setContent('The contest runs until '.Message::timestamp(time()+600, TimestampFormat::SHORT_TIME));
 ```
 
 ## Author

--- a/src/Messages/GuildNavigation.php
+++ b/src/Messages/GuildNavigation.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace DiscordCommands\Messages;
+
+/**
+ * @see https://discord.com/developers/docs/reference#message-formatting-guild-navigation-types
+ */
+enum GuildNavigation: string
+{
+    case SERVER_GUIDE = 'guide';
+    case CHANNEL_BROWSER = 'browse';
+    case CUSTOMIZE_SERVER = 'customize';
+}

--- a/src/Messages/Mention.php
+++ b/src/Messages/Mention.php
@@ -7,14 +7,37 @@ enum Mention: string
     case Everyone = '@everyone';
     case Here = '@here';
 
-    public static function other(int $roleId)
+    public static function user(string $userId): string
     {
-        return '<@&'.$roleId.'>';
+        return '<@' . $userId . '>';
     }
 
-    public static function hasMentions(string $content)
+    public static function role(string $roleId): string
     {
-        return preg_match('#<@&.+?>#', $content) ||
+        return '<@&' . $roleId . '>';
+    }
+
+    public static function everyone(): string
+    {
+        return self::Everyone->value;
+    }
+
+    public static function here(): string
+    {
+        return self::Here->value;
+    }
+
+    /**
+     * @deprecated Use Mention::role() instead
+     */
+    public static function other(int $roleId): string
+    {
+        return self::role($roleId);
+    }
+
+    public static function hasMentions(string $content): bool
+    {
+        return preg_match('#<@.+?>#', $content) ||
             str_contains($content, self::Everyone->value) ||
             str_contains($content, self::Here->value);
     }

--- a/src/Messages/Mention.php
+++ b/src/Messages/Mention.php
@@ -17,16 +17,6 @@ enum Mention: string
         return '<@&' . $roleId . '>';
     }
 
-    public static function everyone(): string
-    {
-        return self::Everyone->value;
-    }
-
-    public static function here(): string
-    {
-        return self::Here->value;
-    }
-
     /**
      * @deprecated Use Mention::role() instead
      */

--- a/src/Messages/Message.php
+++ b/src/Messages/Message.php
@@ -10,6 +10,9 @@ use DiscordCommands\Messages\Components\Types\ActionRow;
 use DiscordCommands\Messages\Components\Types\Button;
 use DiscordCommands\Messages\Embed\Embed;
 
+/**
+ * @see Mention
+ */
 class Message extends Jsonable implements Hydrateable
 {
     use HasComponents;
@@ -86,5 +89,50 @@ class Message extends Jsonable implements Hydrateable
         }
 
         return $jsonData;
+    }
+
+    /**
+     * Adds a link in a channel to a message or embed
+     */
+    public static function linkChannel(string $channelId): string
+    {
+        return '<#' . $channelId . '>';
+    }
+
+    /**
+     * Adds a link to a special guild channel in a message or embed
+     */
+    public static function linkInGuild(GuildNavigation $guildNavigation): string
+    {
+        return '<id:' . $guildNavigation->value . '>';
+    }
+
+    /**
+     * Embeds a custom emoji in a message or embed
+     */
+    public static function customEmoji(
+        string $name,
+        string $id,
+        bool $animated = false
+    ): string {
+        if ($animated) {
+            return '<a:' . $name . ':' . $id . '>';
+        }
+
+        return '<:' . $name . ':' . $id . '>';
+    }
+
+    /**
+     * Render a timestamp in the user's local time in a message or embed
+     */
+    public static function timestamp(
+        int $timestamp,
+        TimestampFormat $format = null
+    ): string {
+        if ($format !== null) {
+            return '<t:' . $timestamp . ':' . $format->value . '>';
+        }
+
+        return '<t:' . $timestamp . '>';
     }
 }

--- a/src/Messages/TimestampFormat.php
+++ b/src/Messages/TimestampFormat.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace DiscordCommands\Messages;
+
+enum TimestampFormat: string
+{
+    case RELATIVE = 'R';
+    case SHORT_TIME = 't';
+    case LONG_TIME = 'T';
+    case SHORT_DATE = 'd';
+    case LONG_DATE = 'D';
+    case SHORT_DATETIME = 'f';
+    case LONG_DATETIME = 'F';
+}

--- a/tests/Messages/MessageTest.php
+++ b/tests/Messages/MessageTest.php
@@ -128,21 +128,48 @@ class MessageTest extends TestCase
     }
 
     /** @test */
-    public function canAddComponentsAsActionRow()
+    public function linksToResources()
     {
-        $this->assertFalse($this->message->hasComponents());
+        $channelId = '48348';
+        $this->assertEquals(
+            '<#'.$channelId.'>',
+            Message::linkChannel($channelId)
+        );
 
-        $compId = '3j34jsdfl';
-        $component = new PrimaryButton($compId);
-        $this->message->actionRow($component);
-        $this->assertTrue($this->message->hasComponents());
+        $this->assertEquals(
+            '<id:'.GuildNavigation::CHANNEL_BROWSER->value.'>',
+            Message::linkInGuild(GuildNavigation::CHANNEL_BROWSER)
+        );
+    }
 
-        $components = $this->message->components();
-        $this->assertInstanceOf(ActionRow::class, $components[0]);
+    /** @test */
+    public function embedsCustomEmoji()
+    {
+        $emojiId = '123848342';
+        $this->assertEquals(
+            '<:smile:'.$emojiId.'>',
+            Message::customEmoji('smile', $emojiId)
+        );
 
-        $json = $this->message->jsonSerialize();
+        $emojiId = '123848342';
+        $this->assertEquals(
+            '<a:smile:'.$emojiId.'>',
+            Message::customEmoji('smile', $emojiId, true)
+        );
+    }
 
-        $this->assertArrayHasKey('components', $json);
-        $this->assertEquals($component->type(), $json['components'][0]['components'][0]['type']);
+    /** @test */
+    public function embedsTimestamps()
+    {
+        $timestamp = time();
+        $this->assertEquals(
+            '<t:' . $timestamp . '>',
+            Message::timestamp($timestamp)
+        );
+
+        $this->assertEquals(
+            '<t:' . $timestamp . ':' . TimestampFormat::RELATIVE->value . '>',
+            Message::timestamp($timestamp, TimestampFormat::RELATIVE)
+        );
     }
 }


### PR DESCRIPTION
Added various methods to help utilize [Discord's message formatting enrichments](https://discord.com/developers/docs/reference#message-formatting) within messages.  This includes linking to channels, embedding timestamps, etc.  This does NOT include embedding commands/sub-sommands