### PR TITLE
Adding clarity that mentions are currently only for roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ Both `Message` and `WebhookMessage` offer the ability to mention roles.
 
 ```php
 // appends the mention to the previously set content.  Setting the content again overrides mentions
-$message->mention($roleId);
+$message->mentionRole($roleId);
 
-$message->isMentioned($roleId);
+$message->isRoleMentioned($roleId);
 $message->hasMentions();
 ```
 

--- a/src/Messages/MentionsRoles.php
+++ b/src/Messages/MentionsRoles.php
@@ -21,27 +21,43 @@ trait MentionsRoles
 
     public function mentionHere()
     {
-        $this->mention(Mention::Here);
+        $this->mentionRole(Mention::Here);
     }
 
     public function mentionEveryone()
     {
-        $this->mention(Mention::Everyone);
+        $this->mentionRole(Mention::Everyone);
     }
 
     /**
      * Mention the given role in the included message
      */
-    public function mention(int|Mention $role): void
+    public function mentionRole(int|Mention $role): void
     {
         if ($role instanceof Mention) {
             $this->content .= $role->value;
         } else {
-            $this->content .= Mention::other($role);
+            $this->content .= Mention::role($role);
         }
     }
 
+    /**
+     * @deprecated Use mentionRole() instead
+     */
+    public function mention(int|Mention $role): void
+    {
+        $this->mentionRole($role);
+    }
+
+    /**
+     * @deprecated Use isRoleMentioned() instead
+     */
     public function isMentioned(int|Mention $role): bool
+    {
+        return $this->isRoleMentioned($role);
+    }
+
+    public function isRoleMentioned(int|Mention $role): bool
     {
         if ($this->content == null) {
             return false;
@@ -51,6 +67,6 @@ trait MentionsRoles
             return str_contains($this->content, $role->value);
         }
 
-        return str_contains($this->content, Mention::other($role));
+        return str_contains($this->content, Mention::role($role));
     }
 }

--- a/tests/Messages/MessageTest.php
+++ b/tests/Messages/MessageTest.php
@@ -24,13 +24,13 @@ class MessageTest extends TestCase
      */
     public function canMentionSpecialRoles(Mention $mention)
     {
-        $this->assertFalse($this->message->isMentioned($mention));
+        $this->assertFalse($this->message->isRoleMentioned($mention));
         $this->assertFalse($this->message->hasMentions());
 
-        $this->message->mention($mention);
+        $this->message->mentionRole($mention);
         $this->assertEquals($mention->value, $this->message->content());
         $this->assertTrue($this->message->hasMentions());
-        $this->assertTrue($this->message->isMentioned($mention));
+        $this->assertTrue($this->message->isRoleMentioned($mention));
     }
 
     public static function mentionableSpecialRoles()
@@ -44,13 +44,13 @@ class MessageTest extends TestCase
     /** @test */
     public function canMentionRoles()
     {
-        $this->assertFalse($this->message->isMentioned(4132));
+        $this->assertFalse($this->message->isRoleMentioned(4132));
         $this->assertFalse($this->message->hasMentions());
 
         $roleId = time();
-        $this->message->mention($roleId);
+        $this->message->mentionRole($roleId);
         $this->assertTrue($this->message->hasMentions());
-        $this->assertTrue($this->message->isMentioned($roleId));
+        $this->assertTrue($this->message->isRoleMentioned($roleId));
     }
 
     /** @test */


### PR DESCRIPTION
We'll need to distinguish between User and Role mentions.  So this PR adjusts all "role" specific mentions and renames the methods, deprecating the generic method names so we can drop them later.