### PR TITLE
Handling Discord's Webhook Events

### DIFF
--- a/src/WebhookEvents/BatchedEvents.php
+++ b/src/WebhookEvents/BatchedEvents.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace DiscordCommands\WebhookEvents;
+
+use DiscordCommands\Hydrateable;
+use DiscordCommands\WebhookEvents\Events\EventFactory;
+
+class BatchedEvents implements Hydrateable
+{
+    public const TYPE = 'BATCHED_EVENTS';
+
+    private string $appId;
+    private array $events = [];
+
+    public function appId(): string
+    {
+        return $this->appId;
+    }
+
+    public function events(): array
+    {
+        return $this->events;
+    }
+
+    public function hydrate(array $array): self
+    {
+        if (isset($array['application_id'])) {
+            $this->appId = $array['application_id'];
+        }
+
+        if (isset($array['data']) && count($array['data']) > 0) {
+            $eventFactory = new EventFactory();
+            foreach($array['data'] as $eventData) {
+                $this->events[] = $eventFactory->make($eventData['type'], $eventData['data']);
+            }
+        }
+
+        return $this;
+    }
+}

--- a/src/WebhookEvents/Events/Event.php
+++ b/src/WebhookEvents/Events/Event.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace DiscordCommands\WebhookEvents\Events;
+
+use DiscordCommands\Hydrateable;
+
+interface Event extends Hydrateable
+{
+    public function id(): string;
+}

--- a/src/WebhookEvents/Events/EventFactory.php
+++ b/src/WebhookEvents/Events/EventFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace DiscordCommands\WebhookEvents\Events;
+
+use DiscordCommands\WebhookEvents\Events\Integrations\IntegrationDeletedEvent;
+
+class EventFactory
+{
+    public function make(string $type, array $data): Event
+    {
+        $event = match ($type) {
+            IntegrationDeletedEvent::TYPE => new IntegrationDeletedEvent(),
+            default => throw new UnrecognizedWebhookEvent(),
+        };
+
+        $event->hydrate($data);
+
+        return $event;
+    }
+}

--- a/src/WebhookEvents/Events/Integrations/IntegrationDeletedEvent.php
+++ b/src/WebhookEvents/Events/Integrations/IntegrationDeletedEvent.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace DiscordCommands\WebhookEvents\Events\Integrations;
+
+use DiscordCommands\WebhookEvents\Events\Event;
+
+class IntegrationDeletedEvent implements Event
+{
+    public const TYPE = 'INTEGRATION_DELETE';
+
+    private ?string $appId;
+    private ?string $guildId;
+    private ?string $id;
+
+    public function appId(): string
+    {
+        return $this->appId;
+    }
+
+    public function guildId(): string
+    {
+        return $this->guildId;
+    }
+
+    public function id(): string
+    {
+        return $this->id;
+    }
+
+    public function hydrate(array $array): self
+    {
+        $this->appId = $array['application_id'];
+        $this->guildId = $array['guild_id'];
+        $this->id = $array['id'];
+
+        return $this;
+    }
+}

--- a/src/WebhookEvents/Events/UnrecognizedWebhookEvent.php
+++ b/src/WebhookEvents/Events/UnrecognizedWebhookEvent.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace DiscordCommands\WebhookEvents\Events;
+
+class UnrecognizedWebhookEvent extends \RuntimeException
+{
+
+}

--- a/src/WebhookEvents/WebhookEventRequestFactory.php
+++ b/src/WebhookEvents/WebhookEventRequestFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace DiscordCommands\WebhookEvents;
+
+class WebhookEventRequestFactory
+{
+    public function make(string $type, array $request): BatchedEvents
+    {
+        $interaction = match ($type) {
+            BatchedEvents::TYPE => new BatchedEvents(),
+        };
+
+        $interaction->hydrate($request);
+
+        return $interaction;
+    }
+}

--- a/tests/WebhookEvents/Events/EventFactoryTest.php
+++ b/tests/WebhookEvents/Events/EventFactoryTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace WebhookEvents\Events;
+
+use DiscordCommands\WebhookEvents\Events\EventFactory;
+use DiscordCommands\WebhookEvents\Events\Integrations\IntegrationDeletedEvent;
+use DiscordCommands\WebhookEvents\Events\UnrecognizedWebhookEvent;
+use PHPUnit\Framework\TestCase;
+
+class EventFactoryTest extends TestCase
+{
+    /** @test */
+    public function makesTypes()
+    {
+        $factory = new EventFactory();
+
+        $this->assertInstanceOf(
+            IntegrationDeletedEvent::class,
+            $factory->make(IntegrationDeletedEvent::TYPE, [
+                'application_id' => '',
+                'guild_id' => '',
+                'id' => '',
+            ])
+        );
+    }
+
+    /** @test */
+    public function throwsExceptionWhenEventNotHandled()
+    {
+        $this->expectException(UnrecognizedWebhookEvent::class);
+
+        $factory = new EventFactory();
+
+        $factory->make('not-an-event', []);
+    }
+}

--- a/tests/WebhookEvents/Events/Integrations/IntegrationDeleteTest.php
+++ b/tests/WebhookEvents/Events/Integrations/IntegrationDeleteTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace WebhookEvents\Events\Integrations;
+
+use DiscordCommands\WebhookEvents\Events\Integrations\IntegrationDeletedEvent;
+use PHPUnit\Framework\TestCase;
+
+class IntegrationDeleteTest extends TestCase
+{
+    private IntegrationDeletedEvent $event;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->event = new IntegrationDeletedEvent();
+    }
+
+    /** @test */
+    public function serializesData()
+    {
+        $appId = 'my-app-id';
+        $guildId = 'my-guild-id';
+        $eventId = 'my-event-id';
+        $this->event->hydrate([
+            'application_id' => $appId,
+            'guild_id' => $guildId,
+            'id' => $eventId,
+        ]);
+
+        $this->assertEquals($appId, $this->event->appId());
+        $this->assertEquals($guildId, $this->event->guildId());
+        $this->assertEquals($eventId, $this->event->id());
+    }
+}

--- a/tests/WebhookEvents/WebhookEventRequestFactoryTest.php
+++ b/tests/WebhookEvents/WebhookEventRequestFactoryTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace WebhookEvents;
+
+use DiscordCommands\WebhookEvents\BatchedEvents;
+use DiscordCommands\WebhookEvents\WebhookEventRequestFactory;
+use PHPUnit\Framework\TestCase;
+
+class WebhookEventRequestFactoryTest extends TestCase
+{
+    /** @test */
+    public function makesTypes()
+    {
+        $factory = new WebhookEventRequestFactory();
+
+        $this->assertInstanceOf(
+            BatchedEvents::class,
+            $factory->make(BatchedEvents::TYPE, [])
+        );
+    }
+}


### PR DESCRIPTION
This PR is a first pass at handling Discord's Webhook Events.  These are still alpha and the events are pretty limited as is documentation, so I'm keeping the initial implementation limited until I can test it and flush it out. more.